### PR TITLE
fix: emptyTrash/deleteItemのN+1削除をNSBatchDeleteRequestに置換 (#52)

### DIFF
--- a/ios/copyPaste/Features/ClipboardHistory/ClipboardHistoryFeature.swift
+++ b/ios/copyPaste/Features/ClipboardHistory/ClipboardHistoryFeature.swift
@@ -601,12 +601,11 @@ struct ClipboardHistoryFeature {
                 return .none
 
             case .emptyTrash:
-                for item in state.trashedItems {
-                    do {
-                        try ClipboardRepository.shared.deleteItem(item)
-                    } catch {
-                        Self.logger.error("Failed to delete item from trash: \(error.localizedDescription)")
-                    }
+                // 個別削除（N+1）ではなく単一トランザクションのバッチ削除を使う
+                do {
+                    try ClipboardRepository.shared.emptyTrash()
+                } catch {
+                    Self.logger.error("Failed to empty trash: \(error.localizedDescription)")
                 }
                 state.trashedItems.removeAll()
                 return .send(.saveTrash)

--- a/ios/copyPaste/Features/ClipboardHistory/ClipboardRepository.swift
+++ b/ios/copyPaste/Features/ClipboardHistory/ClipboardRepository.swift
@@ -59,4 +59,14 @@ final class ClipboardRepository {
     func clearAll() throws {
         try local.clearAll()
     }
+
+    /// ゴミ箱内の全アイテムを一括削除する（NSBatchDeleteRequest）。
+    func emptyTrash() throws {
+        do {
+            try local.emptyTrash()
+        } catch {
+            logger.error("Failed to empty trash: \(error.localizedDescription)")
+            throw error
+        }
+    }
 }

--- a/ios/copyPaste/Features/ClipboardHistory/ClipboardStorageManager.swift
+++ b/ios/copyPaste/Features/ClipboardHistory/ClipboardStorageManager.swift
@@ -87,20 +87,45 @@ class ClipboardStorageManager {
     // MARK: - Delete
 
     func deleteItem(_ item: ClipboardItem) throws {
-        let ctx = PersistenceController.shared.viewContext
-        let request = ClipboardItemEntity.fetchRequest()
-        request.predicate = NSPredicate(format: "id == %@", item.id as CVarArg)
-        guard let entity = try ctx.fetch(request).first else { return }
-        ctx.delete(entity)
-        try ctx.save()
+        try batchDelete(predicate: NSPredicate(format: "id == %@", item.id as CVarArg))
+    }
+
+    /// ゴミ箱内の全アイテムを単一トランザクションで削除する。
+    /// 個別削除（N+1）ではなく NSBatchDeleteRequest を使う。
+    func emptyTrash() throws {
+        try batchDelete(predicate: NSPredicate(format: "isInTrash == YES"))
+        logger.info("Emptied trash via batch delete")
     }
 
     func clearAll() throws {
-        let ctx = PersistenceController.shared.viewContext
-        let request = ClipboardItemEntity.fetchRequest()
-        let entities = (try? ctx.fetch(request)) ?? []
-        entities.forEach { ctx.delete($0) }
-        try ctx.save()
+        try batchDelete(predicate: nil)
+    }
+
+    /// predicate に合致するエンティティを NSBatchDeleteRequest で一括削除する。
+    /// メインスレッドの viewContext ではなくバックグラウンドコンテキストを使い、
+    /// 削除結果（objectID）を viewContext にマージして UI 表示と整合させる。
+    private func batchDelete(predicate: NSPredicate?) throws {
+        let ctx = PersistenceController.shared.newBackgroundContext()
+        var caughtError: Error?
+        ctx.performAndWait {
+            do {
+                let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ClipboardItemEntity")
+                fetchRequest.predicate = predicate
+                let deleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
+                deleteRequest.resultType = .resultTypeObjectIDs
+                let result = try ctx.execute(deleteRequest) as? NSBatchDeleteResult
+                if let objectIDs = result?.result as? [NSManagedObjectID], !objectIDs.isEmpty {
+                    // バッチ削除は永続ストアを直接更新するため、メモリ上のコンテキストへ手動で反映する
+                    NSManagedObjectContext.mergeChanges(
+                        fromRemoteContextSave: [NSDeletedObjectsKey: objectIDs],
+                        into: [PersistenceController.shared.viewContext]
+                    )
+                }
+            } catch {
+                caughtError = error
+            }
+        }
+        if let caughtError { throw caughtError }
     }
 
     // MARK: - Storage Info（CoreData では目安のみ）


### PR DESCRIPTION
## 対応issue
Closes #52

## 変更内容
ゴミ箱全削除 (`emptyTrash`) がアイテム件数分の個別CoreDataトランザクション(N+1)を発生させていた問題を、単一トランザクションのバッチ削除に置き換えました。

- **`ClipboardStorageManager`**: `batchDelete(predicate:)` ヘルパーを新設し、`deleteItem` / `emptyTrash`(新規) / `clearAll` をすべて `NSBatchDeleteRequest` で実装。
  - メインスレッドの `viewContext` ではなく `newBackgroundContext()` を使用。
  - `NSBatchDeleteRequest` は永続ストアを直接更新するため、削除結果の `objectID` を `viewContext` に `mergeChanges(fromRemoteContextSave:)` で反映し、UI表示との整合を確保。
- **`ClipboardRepository`**: `emptyTrash()` を追加（ログ付きラッパー）。
- **`ClipboardHistoryFeature`**: `.emptyTrash` アクションの `for` ループ個別削除を `ClipboardRepository.shared.emptyTrash()` 一回の呼び出しに置換。

100件のゴミ箱 = 100トランザクション → 1トランザクションになります。

## ハーネス検証結果
- ビルド: ✅ (iPhone 16 Pro / iOS 18.6)
- テスト: ✅ `** TEST SUCCEEDED **`（`ClipKitTests` 全件、既存の `testEmptyTrash_clearsAllTrashedItems` 含め成功）
- Lint: ✅ SwiftLint 上、本変更で追加した行に新規違反なし（プロジェクトに `.swiftlint.yml` は無く、既存ファイルの既存違反のみ。スコープ外のため未修正）

## 人間に確認してほしい点
- `deleteItem` / `clearAll` / `emptyTrash` の API は同期 `throws` のまま維持しています（呼び出し側が同期コンテキストのため）。内部はバックグラウンドコンテキスト + `performAndWait` でバッチ削除します。完全な非同期化(`async`)まで踏み込むかは別途判断ください。
- `NSBatchDeleteRequest` は in-memory(`/dev/null` SQLite)ストアでも動作するためテストは通っていますが、本番のCloudKit同期ストアでのバッチ削除のCloudKitミラーリング挙動は実機での最終確認が望ましいです。

---
*このPRは resolve-issues スキルにより作成されました*