### PR TITLE
test: JSONMigration・EncryptionHelperのユニットテストを追加 (#53)

### DIFF
--- a/ios/copyPasteTests/EncryptionHelperTests.swift
+++ b/ios/copyPasteTests/EncryptionHelperTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import ClipKit
+
+/// EncryptionHelper（AES-GCM 暗号化 + Keychain 鍵管理）のテスト。
+///
+/// Keychain を伴うため、エンタイトルメントが揃わない実行環境では Keychain 操作が
+/// 失敗しうる。その場合は XCTSkip して赤化を避けつつ、可能な環境では暗号の
+/// 往復（roundtrip）と改ざん検知を担保する。
+final class EncryptionHelperTests: XCTestCase {
+
+    /// Keychain が利用可能か確認し、不可なら以降をスキップする。
+    private func requireEncryptionAvailable() throws {
+        do {
+            _ = try EncryptionHelper.encrypt(Data([0x00]))
+        } catch {
+            throw XCTSkip("Keychain unavailable in this test environment: \(error)")
+        }
+    }
+
+    // MARK: - Roundtrip
+
+    func testEncryptDecrypt_roundtrip_succeeds() throws {
+        try requireEncryptionAvailable()
+
+        let original = Data("Hello, ClipKit! 🔐 機密データ".utf8)
+        let encrypted = try EncryptionHelper.encrypt(original)
+        let decrypted = try EncryptionHelper.decrypt(encrypted)
+
+        XCTAssertEqual(decrypted, original, "復号結果は元データと一致すること（データロスがないこと）")
+        XCTAssertNotEqual(encrypted, original, "暗号文は平文と異なること")
+    }
+
+    func testEncryptDecrypt_roundtrip_emptyData() throws {
+        try requireEncryptionAvailable()
+
+        let original = Data()
+        let decrypted = try EncryptionHelper.decrypt(EncryptionHelper.encrypt(original))
+
+        XCTAssertEqual(decrypted, original, "空データでも往復で一致すること")
+    }
+
+    func testEncryptDecrypt_roundtrip_largeBinaryData() throws {
+        try requireEncryptionAvailable()
+
+        var original = Data(count: 256 * 1024)
+        original.withUnsafeMutableBytes { buffer in
+            for index in 0..<buffer.count { buffer[index] = UInt8(index % 256) }
+        }
+        let decrypted = try EncryptionHelper.decrypt(EncryptionHelper.encrypt(original))
+
+        XCTAssertEqual(decrypted, original, "大きなバイナリでも往復でビット単位に一致すること")
+    }
+
+    func testEncrypt_samedPlaintext_producesDifferentCiphertextButDecryptsBack() throws {
+        try requireEncryptionAvailable()
+
+        let original = Data("repeat".utf8)
+        let first = try EncryptionHelper.encrypt(original)
+        let second = try EncryptionHelper.encrypt(original)
+
+        XCTAssertNotEqual(first, second, "AES-GCM の nonce はランダムなので暗号文は毎回異なること")
+        XCTAssertEqual(try EncryptionHelper.decrypt(first), original)
+        XCTAssertEqual(try EncryptionHelper.decrypt(second), original)
+    }
+
+    // MARK: - Tamper detection
+
+    func testDecrypt_withTamperedData_throwsError() throws {
+        try requireEncryptionAvailable()
+
+        let original = Data("integrity-protected".utf8)
+        var encrypted = try EncryptionHelper.encrypt(original)
+        // 末尾（認証タグ付近）の 1 バイトを反転させて改ざんを再現する
+        let lastIndex = encrypted.index(before: encrypted.endIndex)
+        encrypted[lastIndex] ^= 0xFF
+
+        XCTAssertThrowsError(try EncryptionHelper.decrypt(encrypted), "改ざんされた暗号文は復号に失敗すること")
+    }
+
+    func testDecrypt_withTruncatedData_throwsError() throws {
+        try requireEncryptionAvailable()
+
+        let encrypted = try EncryptionHelper.encrypt(Data("truncate-me".utf8))
+        let truncated = encrypted.prefix(8) // SealedBox を構成できない短さ
+
+        XCTAssertThrowsError(try EncryptionHelper.decrypt(truncated), "不正な長さのデータは復号に失敗すること")
+    }
+
+    // MARK: - Key persistence (Keychain consistency)
+
+    func testKeyConsistency_decryptsCiphertextAcrossSeparateCalls() throws {
+        try requireEncryptionAvailable()
+
+        // encrypt と decrypt は別呼び出しで Keychain から同じ鍵を取得する。
+        // 鍵が一貫して取り出せていなければ復号できない。
+        let original = Data("persisted-key".utf8)
+        let encrypted = try EncryptionHelper.encrypt(original)
+        let decrypted = try EncryptionHelper.decrypt(encrypted)
+
+        XCTAssertEqual(decrypted, original, "Keychain から取得した鍵が一貫していること")
+    }
+}

--- a/ios/copyPasteTests/JSONMigrationTests.swift
+++ b/ios/copyPasteTests/JSONMigrationTests.swift
@@ -1,0 +1,169 @@
+import XCTest
+@testable import ClipKit
+
+/// JSONMigration（旧 JSON ストレージ → CoreData へのデータ移行）のテスト。
+///
+/// 移行失敗は既存ユーザーのデータロスに直結するため、
+/// - 平文/暗号化された旧データが欠落なく移行されること（roundtrip）
+/// - 破損データでクラッシュせず安全に処理されること
+/// - 既に移行済みなら再実行されないこと（旧データを上書き・消失させない）
+/// を担保する。
+///
+/// App Group コンテナにアクセスできない実行環境では XCTSkip する。
+final class JSONMigrationTests: XCTestCase {
+
+    private let migrationKey = "coreDataMigrationCompleted_v1"
+
+    /// 旧データを書き込む App Group 内のディレクトリ。entitlement が無ければ nil。
+    private var baseDir: URL? {
+        guard let container = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: SharedConstants.appGroupID
+        ) else { return nil }
+        return container.appendingPathComponent(SharedConstants.storageDirectoryName)
+    }
+
+    // MARK: - Lifecycle
+
+    override func setUp() async throws {
+        try await super.setUp()
+        try resetEnvironment()
+    }
+
+    override func tearDown() async throws {
+        try resetEnvironment()
+        try await super.tearDown()
+    }
+
+    /// CoreData・移行フラグ・旧ファイルをまっさらにして各テストを独立させる。
+    private func resetEnvironment() throws {
+        try? ClipboardStorageManager.shared.clearAll()
+        SharedConstants.sharedDefaults?.removeObject(forKey: migrationKey)
+        guard let baseDir else { return }
+        for name in ["items.json", "trash.json"] {
+            try? FileManager.default.removeItem(at: baseDir.appendingPathComponent(name))
+        }
+        try? FileManager.default.createDirectory(at: baseDir, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Helpers
+
+    /// 旧 JSON 形式（LegacyMetadata 互換）にエンコードできる最小モデル。
+    private struct LegacyItemFixture: Codable {
+        let id: UUID
+        let timestamp: Date
+        let type: String
+        var isFavorite: Bool = false
+        var textContent: String?
+        var deletedAt: Date?
+    }
+
+    private func legacyJSONData(_ items: [LegacyItemFixture]) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(items)
+    }
+
+    private func write(_ data: Data, to fileName: String) throws -> URL {
+        let dir = try XCTUnwrap(baseDir, "App Group container is unavailable")
+        let url = dir.appendingPathComponent(fileName)
+        try data.write(to: url)
+        return url
+    }
+
+    private func textItem(_ text: String, deletedAt: Date? = nil) -> LegacyItemFixture {
+        LegacyItemFixture(
+            id: UUID(),
+            timestamp: Date(),
+            type: "text",
+            textContent: text,
+            deletedAt: deletedAt
+        )
+    }
+
+    private func skipIfNoContainer() throws {
+        if baseDir == nil {
+            throw XCTSkip("App Group container unavailable in this test environment")
+        }
+    }
+
+    // MARK: - Tests
+
+    func testMigrateIfNeeded_withLegacyData_migratesSuccessfully() async throws {
+        try skipIfNoContainer()
+
+        let items = [textItem("alpha"), textItem("beta")]
+        let trash = [textItem("trashed", deletedAt: Date())]
+        _ = try write(try legacyJSONData(items), to: "items.json")
+        _ = try write(try legacyJSONData(trash), to: "trash.json")
+
+        await JSONMigration.migrateIfNeeded()
+
+        let migratedItems = try await ClipboardStorageManager.shared.load()
+        let migratedTrash = try await ClipboardStorageManager.shared.loadTrash()
+
+        XCTAssertEqual(Set(migratedItems.compactMap { $0.textContent }), ["alpha", "beta"],
+                       "全アイテムが欠落なく移行されること")
+        XCTAssertEqual(migratedTrash.compactMap { $0.textContent }, ["trashed"],
+                       "ゴミ箱データも移行されること")
+        XCTAssertTrue(SharedConstants.sharedDefaults?.bool(forKey: migrationKey) ?? false,
+                      "移行完了フラグが立つこと")
+    }
+
+    func testMigrateIfNeeded_deletesLegacyFilesAfterSuccess() async throws {
+        try skipIfNoContainer()
+
+        let itemsURL = try write(try legacyJSONData([textItem("x")]), to: "items.json")
+
+        await JSONMigration.migrateIfNeeded()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: itemsURL.path),
+                       "移行成功後は旧 JSON ファイルが削除されること")
+    }
+
+    func testMigrateIfNeeded_withEncryptedData_decryptsCorrectly() async throws {
+        try skipIfNoContainer()
+
+        let plain = try legacyJSONData([textItem("secret-payload")])
+        let encrypted: Data
+        do {
+            encrypted = try EncryptionHelper.encrypt(plain)
+        } catch {
+            throw XCTSkip("Keychain unavailable, cannot prepare encrypted fixture: \(error)")
+        }
+        _ = try write(encrypted, to: "items.json")
+
+        await JSONMigration.migrateIfNeeded()
+
+        let migrated = try await ClipboardStorageManager.shared.load()
+        XCTAssertEqual(migrated.compactMap { $0.textContent }, ["secret-payload"],
+                       "暗号化された旧データも復号して移行されること（暗号往復）")
+    }
+
+    func testMigrateIfNeeded_withCorruptedData_handlesGracefully() async throws {
+        try skipIfNoContainer()
+
+        // 復号もデコードもできないゴミデータ
+        _ = try write(Data([0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01]), to: "items.json")
+
+        // クラッシュせず完了すること
+        await JSONMigration.migrateIfNeeded()
+
+        let migrated = try await ClipboardStorageManager.shared.load()
+        XCTAssertTrue(migrated.isEmpty, "破損データからは何も移行されないこと（データ生成されないこと）")
+    }
+
+    func testMigrateIfNeeded_whenAlreadyMigrated_skipsRerun() async throws {
+        try skipIfNoContainer()
+
+        // 既に移行済みフラグを立てた状態で旧ファイルを置く
+        SharedConstants.sharedDefaults?.set(true, forKey: migrationKey)
+        let itemsURL = try write(try legacyJSONData([textItem("should-not-migrate")]), to: "items.json")
+
+        await JSONMigration.migrateIfNeeded()
+
+        let migrated = try await ClipboardStorageManager.shared.load()
+        XCTAssertTrue(migrated.isEmpty, "移行済みなら再移行しないこと")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: itemsURL.path),
+                      "移行済みなら旧ファイルを削除しない（既存データを保持する）こと")
+    }
+}


### PR DESCRIPTION
## 対応issue
Closes #53

## 変更内容
リリースで追加されたがテストが無かった重要コンポーネントにユニットテストを追加しました。データロスと暗号の往復(roundtrip)を担保するケースを必ず含めています。新規ファイルのみで、プロダクションコードは変更していません（`copyPasteTests` は File System Synchronized Group のため pbxproj 編集不要）。

### `EncryptionHelperTests.swift`（7ケース）
- `testEncryptDecrypt_roundtrip_succeeds` / `_emptyData` / `_largeBinaryData` — **暗号往復**で元データと完全一致（データロスなし）
- `testEncrypt_samedPlaintext_producesDifferentCiphertextButDecryptsBack` — AES-GCM nonce のランダム性、かつ双方とも復号可
- `testDecrypt_withTamperedData_throwsError` / `_withTruncatedData_throwsError` — 改ざん・破損検知
- `testKeyConsistency_decryptsCiphertextAcrossSeparateCalls` — Keychain 鍵の一貫取得

### `JSONMigrationTests.swift`（5ケース）
- `testMigrateIfNeeded_withLegacyData_migratesSuccessfully` — 旧データ（本体＋ゴミ箱）が欠落なく CoreData へ移行
- `testMigrateIfNeeded_deletesLegacyFilesAfterSuccess` — 移行成功後に旧ファイル削除
- `testMigrateIfNeeded_withEncryptedData_decryptsCorrectly` — **暗号化された旧データの復号→移行（暗号往復）**
- `testMigrateIfNeeded_withCorruptedData_handlesGracefully` — 破損データでクラッシュせず、誤データを生成しない
- `testMigrateIfNeeded_whenAlreadyMigrated_skipsRerun` — 移行済みなら再実行せず既存ファイルを保持（データ消失防止）

各テストは独立性のため setUp/tearDown で CoreData・移行フラグ・旧ファイルをリセット。App Group コンテナ／Keychain が使えない環境では `XCTSkip` して赤化を回避します。

## ハーネス検証結果
- ビルド: ✅ (iPhone 16 Pro / iOS 18.6)
- テスト: ✅ `** TEST SUCCEEDED **`（新規 **12ケースすべて pass**、スキップなし。ホスト環境で Keychain・App Group とも利用可）
- Lint: ✅ SwiftLint 上、新規2ファイルに違反なし

## 人間に確認してほしい点
- 当初issueにあった `PersistenceController` のテストは今回スコープ外としました（in-memory store 初期化の検証は他テストが間接的にカバーしているため）。明示的なテストが必要なら追加します。
- `JSONMigration` テストは実 App Group コンテナへ一時ファイルを書き込みます（テスト内でクリーンアップ済み）。CI で App Group entitlement が無い場合は自動 skip されます。

---
*このPRは resolve-issues スキルにより作成されました*