### PR TITLE
feat(aso): en-USストアの英語タイトル・サブタイトルを追加

### DIFF
--- a/fastlane/metadata/en-US/name.txt
+++ b/fastlane/metadata/en-US/name.txt
@@ -1,0 +1,1 @@
+ClipKit - Clipboard Manager

--- a/fastlane/metadata/en-US/privacy_url.txt
+++ b/fastlane/metadata/en-US/privacy_url.txt
@@ -1,0 +1,1 @@
+https://clipkit-entaku.web.app/privacy-policy.html

--- a/fastlane/metadata/en-US/subtitle.txt
+++ b/fastlane/metadata/en-US/subtitle.txt
@@ -1,0 +1,1 @@
+Save, search & paste history


### PR DESCRIPTION
## 概要

英語圏ストア（US等）でアプリタイトルが日本語の旧タイトル「ClipKit - クリップボード管理」のまま放置されていた問題を解消する。原因は `fastlane/metadata/en-US/` に `name.txt` / `subtitle.txt` が存在せず、ja のタイトルがフォールバック表示されていたこと。

## 変更内容

| ファイル | 内容 | 文字数 |
|---|---|---|
| `en-US/name.txt` | `ClipKit - Clipboard Manager` | 27/30 |
| `en-US/subtitle.txt` | `Save, search & paste history` | 28/30 |
| `en-US/privacy_url.txt` | ja と同じプライバシーポリシーURL | - |

キーワード（`clipboard,copy paste,history,manager` 等）は既存の `en-US/keywords.txt` と整合。

## 反映タイミング（要確認）

- 現在 1.3.1 (build 21) が審査中のため、審査中バージョンのメタデータは編集不可
- このメタデータは**次回バージョンの審査申請時**（`fastlane release` / `submit_build`、いずれも `metadata_path: fastlane/metadata` を使用）に自動反映される
- `fastlane update_metadata`（`edit_live: true`）はライブ版が編集不可状態のため使用不可

🤖 Generated with [Claude Code](https://claude.com/claude-code)