### PR TITLE
fix: TCAを1.26.0に更新しXcode 26.5のビルドエラーを解消

### DIFF
--- a/ios/copyPaste.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/copyPaste.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "38d0592c4979ac92486d80bc0d1bfef3c313bb9f4f0869271256783111ccc049",
+  "originHash" : "92a02986b5d1a5547770479ec2219ccaa4681e92921d138fe1e65fe735d4ba92",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-composable-architecture.git",
       "state" : {
-        "revision" : "5b0890fabfd68a2d375d68502bc3f54a8548c494",
-        "version" : "1.23.1"
+        "revision" : "e2fa1df6cd9eec6fa6314aa20513e47da576f24e",
+        "version" : "1.26.0"
       }
     },
     {
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-navigation",
       "state" : {
-        "revision" : "bf498690e1f6b4af790260f542e8428a4ba10d78",
-        "version" : "2.6.0"
+        "revision" : "32f35241b8be0719c4c7f00eb27713b1cadb6248",
+        "version" : "2.8.0"
       }
     },
     {


### PR DESCRIPTION
## 概要

Xcode 26.5でTCA 1.23.1のコンパイルが `Type 'WritableKeyPath<Root, Value>' does not conform to the 'Sendable' protocol` で失敗し、プロジェクト全体のビルド・テストが通らない状態だった（クリーンビルドでも再現）。

TCA公式の既知問題（pointfreeco/swift-composable-architecture#3899, #3854）で、Xcode 26/27対応が入った1.26.0で修正済み。

## 変更内容

- `Package.resolved`: swift-composable-architecture 1.23.1 → 1.26.0
- 推移的依存: swift-navigation 2.6.0 → 2.8.0（TCA 1.26.0の要件）
- pbxprojのバージョン要件は `upToNextMajor from 1.21.0` のため変更なし

## 検証

- `xcodebuild build-for-testing`: ✅ TEST BUILD SUCCEEDED
- `ClipKitTests` 全58テスト: ✅ 全件パス（iPhone 16 Pro Max / iOS 18.4 シミュレータ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)