### PR TITLE
feat: 買い切りプラン（永久利用）を追加

### DIFF
--- a/ios/copyPaste/Features/Subscription/PaywallView.swift
+++ b/ios/copyPaste/Features/Subscription/PaywallView.swift
@@ -122,6 +122,9 @@ struct PaywallView: View {
                             if isPurchasing {
                                 ProgressView()
                                     .tint(.white)
+                            } else if selectedPackage?.packageType == .lifetime {
+                                Text("購入する")
+                                    .fontWeight(.semibold)
                             } else if let trialText = selectedPackageTrialText {
                                 Text("無料で試す（\(trialText)）")
                                     .fontWeight(.semibold)
@@ -167,15 +170,19 @@ struct PaywallView: View {
 
                     // 注意事項・リンク
                     VStack(spacing: 8) {
-                        if let trialText = selectedPackageTrialText {
-                            Text("• \(trialText)の無料トライアル")
+                        if selectedPackage?.packageType == .lifetime {
+                            Text("• 一度の購入で永久に利用できます")
+                            Text("• Apple IDアカウントに課金されます")
+                        } else {
+                            if let trialText = selectedPackageTrialText {
+                                Text("• \(trialText)の無料トライアル")
+                            }
+                            if let periodText = selectedPackagePeriodText {
+                                Text("• \(periodText)ごとに自動更新")
+                            }
+                            Text("• いつでもキャンセル可能")
+                            Text("• Apple IDアカウントに課金されます")
                         }
-                        if let periodText = selectedPackagePeriodText {
-                            Text("• \(periodText)ごとに自動更新")
-                        }
-                        Text("• いつでもキャンセル可能")
-                        Text("• Apple IDアカウントに課金されます")
-
                     }
                     .font(.caption)
                     .foregroundColor(.secondary)
@@ -425,12 +432,17 @@ struct PackageButton: View {
             return NSLocalizedString("paywall.package.monthly", value: "月間プラン", comment: "")
         case .annual:
             return NSLocalizedString("paywall.package.annual", value: "年間プラン", comment: "")
+        case .lifetime:
+            return NSLocalizedString("paywall.package.lifetime", value: "買い切りプラン", comment: "")
         default:
             return package.storeProduct.localizedTitle
         }
     }
 
     private var subscriptionPeriodText: String {
+        if package.packageType == .lifetime {
+            return NSLocalizedString("paywall.renewal.lifetime", value: "一度の購入で永久に利用可能", comment: "")
+        }
         guard let period = package.storeProduct.subscriptionPeriod else { return "" }
         switch (period.unit, period.value) {
         case (.month, 1): return NSLocalizedString("paywall.renewal.monthly", value: "1ヶ月ごとに自動更新", comment: "")


### PR DESCRIPTION
## 概要

ClipKit Pro に買い切りプラン（`com.entaku.clipkit.pro.lifetime`）を追加。

## App Store Connect 設定済み内容

| 項目 | 値 |
|---|---|
| IAP ID | 6779861294 |
| ProductID | `com.entaku.clipkit.pro.lifetime` |
| タイプ | NON_CONSUMABLE（非消耗型）|
| 価格 JPN | ¥5,000 |
| 価格 USA | Apple 自動換算（JPN 基準） |
| ja 名称 | 買い切りプラン（永久利用） |
| en-US 名称 | Lifetime Access |
| State | MISSING_METADATA（審査用スクショ未設定） |

> **要確認**: USA 価格は API から手動設定不可のため Apple 自動換算。App Store Connect Web UI で確認・調整を推奨（$29.99 ～ $34.99 前後になる見込み）。

## アプリ側変更

- `PackageButton.packageTitle`: `.lifetime` → 「買い切りプラン」
- `subscriptionPeriodText`: lifetime 時は「一度の購入で永久に利用可能」
- 購入ボタン文言: lifetime 選択時は「購入する」
- 注意事項: lifetime 時は自動更新・キャンセル文言を非表示、代わりに「一度の購入で永久に利用できます」

## マージ後に必要な手動作業（RevenueCat）

1. [RevenueCat Dashboard](https://app.revenuecat.com) → Products → `com.entaku.clipkit.pro.lifetime` を追加
2. Entitlements → `pro` にアタッチ
3. Offerings → current offering → Package 追加（`.lifetime` タイプで上記 product を設定）
4. ASC 側で IAP 審査申請（スクショ設定後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)