### PR TITLE
docs: CLAUDE.mdにXcode Cloud移行後のCI検証範囲を明記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@
 
 - SwiftLint: `swiftlint lint`
 - iOS build/test: `xcodebuild test -project ios/copyPaste.xcodeproj -scheme ClipKit -destination "id=<SIMULATOR_UDID>" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
+  - 注意: `.github/workflows/ci.yml` は SwiftLint と Functions ビルドのみを実行し、iOS のビルド/テストは GitHub Actions では実行されない（Xcode Cloud 移行後もPRゲートとしての構成は未確認）。上記コマンドでのローカル/エージェントによる実行が現状唯一の検証手段
 - Functions lint: `cd functions && npm run lint`
 - Functions build (tsc): `cd functions && npm run build`
 
@@ -24,6 +25,7 @@
 - 実装は build / test / lint が緑になるまで自己修正する（コマンド: `swiftlint lint` / `xcodebuild test -project ios/copyPaste.xcodeproj -scheme ClipKit -destination "id=<SIMULATOR_UDID>" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""` / `cd functions && npm run lint && npm run build`）
 - **緑でない変更を main に入れない**。5回で緑にならなければブランチに残して報告
 - 完了報告には実行した検証コマンドと実出力を含める（「たぶん動く」は完了ではない）
+- `ios-test` の GitHub Actions ジョブは削除済み（commit `4e6cd3d`）。main へのマージは CI による iOS build/test の自動ゲートを受けないため、マージ前にローカルで `xcodebuild test` を回す自己修正ループがこの検証の唯一の担保であり、省略してはならない
 
 ### エスカレーション（諦め方の設計）
 - 同一 issue に2回挑戦して解けない → `loop-attempted` ラベルを付けて人間へ


### PR DESCRIPTION
## 背景

commit `4e6cd3d`（"ci: iOS CI(macOSランナー)を削除、Xcode Cloudへ移行"）で GitHub Actions の `ios-test` ジョブ（`xcodebuild test` 実行）が削除されました。現在の `.github/workflows/ci.yml` には `swiftlint` と `functions-build` の2ジョブしかなく、iOS の build/test を GitHub Actions 上で自動実行・検証する仕組みはありません。

`CLAUDE.md` はこの移行の直前に書かれた内容のままで、「ループ運用（Loop Engineering）」節が iOS build/test も CI で緑になることを前提にしているかのように読めてしまうため、実態と齟齬がありました。

## 変更内容（ドキュメントのみ、`ios/` 配下・CIワークフローは無変更）

`CLAUDE.md` に以下の2箇所を追記しました。

1. **Common Commands** の iOS build/test コマンドの直下に注記を追加:
   > 注意: `.github/workflows/ci.yml` は SwiftLint と Functions ビルドのみを実行し、iOS のビルド/テストは GitHub Actions では実行されない（Xcode Cloud 移行後もPRゲートとしての構成は未確認）。上記コマンドでのローカル/エージェントによる実行が現状唯一の検証手段

2. **ループ運用（Loop Engineering）→ ハーネス（検証ゲート）** に一文追加:
   > `ios-test` の GitHub Actions ジョブは削除済み（commit `4e6cd3d`）。main へのマージは CI による iOS build/test の自動ゲートを受けないため、マージ前にローカルで `xcodebuild test` を回す自己修正ループがこの検証の唯一の担保であり、省略してはならない

## 補足（要確認事項）

Xcode Cloud がリポジトリ側で実際に PR ゲートとして構成されているかどうかは、このリポジトリのファイルからは確認できません（App Store Connect 側の設定が必要）。上記の注記では「未確認」として明示し、断定は避けています。もし Xcode Cloud 側で同等の検証が構成済みであれば、その旨を教えていただければ文言を調整します。

## 検証

- `swiftlint lint`: exit code 0、75 warnings / 0 serious（すべて本PR変更と無関係な既存ファイルの警告。ドキュメントのみの変更につき影響なし）
- Swift/Xcodeビルド・テストは本issueの性質上（ドキュメントのみの変更）実行していません

Refs #99