### PR TITLE
test: 非同期タイミング修正（CoreDataストア読み込み待ち・PiP中overflow）にテストを追加

### DIFF
--- a/ios/copyPaste/CoreData/PersistenceController.swift
+++ b/ios/copyPaste/CoreData/PersistenceController.swift
@@ -90,7 +90,12 @@ final class PersistenceController {
         }
     }
 
-    init(useCloudKit: Bool = true, inMemory: Bool = false) {
+    /// - Parameters:
+    ///   - storeURL: テスト用途のフック。非nilの場合、App Groupコンテナのルックアップを
+    ///     スキップしてこのURLから直接ストアを構成する（例: 存在しないディレクトリを指す
+    ///     URLを渡すことで、ストア読み込み失敗を意図的に注入できる）。
+    ///     `inMemory: true`の場合はこのパラメータは無視される。
+    init(useCloudKit: Bool = true, inMemory: Bool = false, storeURL: URL? = nil) {
         if useCloudKit {
             container = NSPersistentCloudKitContainer(name: "ClipboardDataModel")
         } else {
@@ -99,6 +104,31 @@ final class PersistenceController {
 
         if inMemory {
             container.persistentStoreDescriptions.first?.url = URL(fileURLWithPath: "/dev/null")
+        } else if let storeURL {
+            let description = NSPersistentStoreDescription(url: storeURL)
+
+            if useCloudKit {
+                description.cloudKitContainerOptions = NSPersistentCloudKitContainerOptions(
+                    containerIdentifier: "iCloud.com.entaku.clipkit"
+                )
+            }
+
+            // 拡張機能がメインアプリの変更を受け取るために必要
+            description.setOption(true as NSNumber, forKey: NSPersistentHistoryTrackingKey)
+            description.setOption(
+                true as NSNumber,
+                forKey: NSPersistentStoreRemoteChangeNotificationPostOptionKey
+            )
+            // v1 → v2 自動マイグレーション（categoryRaw/ocrText フィールド追加）
+            description.shouldMigrateStoreAutomatically = true
+            description.shouldInferMappingModelAutomatically = true
+            // NSFileProtection: デバイスロック中でも拡張機能が読めるよう CompleteUnlessOpen を使用
+            description.setOption(
+                FileProtectionType.completeUnlessOpen as NSObject,
+                forKey: NSPersistentStoreFileProtectionKey
+            )
+
+            container.persistentStoreDescriptions = [description]
         } else {
             guard let groupURL = FileManager.default.containerURL(
                 forSecurityApplicationGroupIdentifier: SharedConstants.appGroupID
@@ -112,8 +142,8 @@ final class PersistenceController {
                 return
             }
 
-            let storeURL = groupURL.appendingPathComponent("ClipboardData.sqlite")
-            let description = NSPersistentStoreDescription(url: storeURL)
+            let groupStoreURL = groupURL.appendingPathComponent("ClipboardData.sqlite")
+            let description = NSPersistentStoreDescription(url: groupStoreURL)
 
             if useCloudKit {
                 description.cloudKitContainerOptions = NSPersistentCloudKitContainerOptions(

--- a/ios/copyPaste/Features/ClipboardHistory/ClipboardItemRow.swift
+++ b/ios/copyPaste/Features/ClipboardHistory/ClipboardItemRow.swift
@@ -69,14 +69,23 @@ struct ClipboardItemRow: View {
         }
     }
 
+    /// テキストアイテムの表示文言を決定する純粋関数。
+    /// nil/空文字列の場合はプレースホルダーを返し、isEmptyをtrueにする。
+    static func displayText(for textContent: String?) -> (text: String, isEmpty: Bool) {
+        if let textContent, !textContent.isEmpty {
+            return (textContent, false)
+        }
+        return (String(localized: "item.text.empty"), true)
+    }
+
     @ViewBuilder
     private var itemContent: some View {
         switch item.type {
         case .text:
-            let text = item.textContent
-            Text(text?.isEmpty == false ? text! : String(localized: "item.text.empty"))
+            let display = Self.displayText(for: item.textContent)
+            Text(display.text)
                 .font(ClipKitFont.rowTitle)
-                .foregroundColor(text?.isEmpty == false ? ClipKitColor.textPrimary : ClipKitColor.textTertiary)
+                .foregroundColor(display.isEmpty ? ClipKitColor.textTertiary : ClipKitColor.textPrimary)
                 .lineLimit(2)
 
         case .image:

--- a/ios/copyPasteTests/ClipboardHistoryFeatureTests.swift
+++ b/ios/copyPasteTests/ClipboardHistoryFeatureTests.swift
@@ -546,6 +546,86 @@ final class ClipboardHistoryFeatureTests: XCTestCase {
         await store.finish()
     }
 
+    func testAddItem_nonPiP_overflowCallsDeleteItem() async {
+        let oldestItemID = UUID()
+        let oldestItem = ClipboardItem(
+            id: oldestItemID, content: "Oldest Item",
+            timestamp: Date(timeIntervalSince1970: 0)
+        )
+        var existing = (1...19).map { i in
+            ClipboardItem(id: UUID(), content: "Item \(i)",
+                          timestamp: Date(timeIntervalSince1970: Double(20 - i)))
+        }
+        existing.append(oldestItem)
+
+        let newItem = ClipboardItem(content: "New Item")
+        let initialState = ClipboardHistoryFeature.State(
+            items: existing, isPiPActive: false, isProUser: false
+        )
+        let deletedItems = LockIsolated<[ClipboardItem]>([])
+        let store = TestStore(initialState: initialState) {
+            ClipboardHistoryFeature()
+        } withDependencies: {
+            $0.clipboardRepository.deleteItem = { item in
+                deletedItems.withValue { $0.append(item) }
+            }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.addItem(newItem))
+        await store.finish()
+
+        XCTAssertEqual(store.state.items.count, 20, "上限を超えないこと")
+        XCTAssertEqual(deletedItems.value.count, 1, "非PiP時はdeleteItemが1回呼ばれること")
+        XCTAssertEqual(
+            deletedItems.value.first?.id, oldestItemID,
+            "追い出された最古のアイテムでdeleteItemが呼ばれること"
+        )
+    }
+
+    func testAddItem_piPActive_overflowSkipsDeleteItemAndBuffersItem() async {
+        let oldestItemID = UUID()
+        let oldestItem = ClipboardItem(
+            id: oldestItemID, content: "Oldest Item",
+            timestamp: Date(timeIntervalSince1970: 0)
+        )
+        var existing = (1...19).map { i in
+            ClipboardItem(id: UUID(), content: "Item \(i)",
+                          timestamp: Date(timeIntervalSince1970: Double(20 - i)))
+        }
+        existing.append(oldestItem)
+
+        let newItem = ClipboardItem(content: "New Item")
+        let initialState = ClipboardHistoryFeature.State(
+            items: existing, isPiPActive: true, isProUser: false
+        )
+        let deletedItems = LockIsolated<[ClipboardItem]>([])
+        let bufferedItems = LockIsolated<[ClipboardItem]>([])
+        let store = TestStore(initialState: initialState) {
+            ClipboardHistoryFeature()
+        } withDependencies: {
+            $0.clipboardRepository.deleteItem = { item in
+                deletedItems.withValue { $0.append(item) }
+            }
+            $0.pendingItemBuffer.append = { item in
+                bufferedItems.withValue { $0.append(item) }
+            }
+        }
+        store.exhaustivity = .off
+
+        await store.send(.addItem(newItem))
+        await store.finish()
+
+        XCTAssertEqual(store.state.items.count, 20, "PiP中でも上限を超えず縮むこと")
+        XCTAssertEqual(store.state.items.first?.id, newItem.id, "新アイテムが先頭に入ること")
+        XCTAssertTrue(
+            deletedItems.value.isEmpty,
+            "PiP中はCoreData書き込みを避けるためdeleteItemが呼ばれないこと"
+        )
+        XCTAssertEqual(bufferedItems.value.count, 1, "PiP中は新アイテムがpendingBufferに積まれること")
+        XCTAssertEqual(bufferedItems.value.first?.id, newItem.id)
+    }
+
     func testAddItem_incrementsCaptureCount() async {
         let item = ClipboardItem(content: "Test")
         var initialState = ClipboardHistoryFeature.State()

--- a/ios/copyPasteTests/ClipboardItemRowTests.swift
+++ b/ios/copyPasteTests/ClipboardItemRowTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import ClipKit
+
+final class ClipboardItemRowTests: XCTestCase {
+    func testDisplayText_nilContent_returnsPlaceholderAndIsEmpty() {
+        let result = ClipboardItemRow.displayText(for: nil)
+
+        XCTAssertEqual(result.text, String(localized: "item.text.empty"))
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testDisplayText_emptyStringContent_returnsPlaceholderAndIsEmpty() {
+        let result = ClipboardItemRow.displayText(for: "")
+
+        XCTAssertEqual(result.text, String(localized: "item.text.empty"))
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testDisplayText_normalContent_returnsTextAndIsNotEmpty() {
+        let result = ClipboardItemRow.displayText(for: "Hello, ClipKit!")
+
+        XCTAssertEqual(result.text, "Hello, ClipKit!")
+        XCTAssertFalse(result.isEmpty)
+    }
+}

--- a/ios/copyPasteTests/CloudKitSyncModeTests.swift
+++ b/ios/copyPasteTests/CloudKitSyncModeTests.swift
@@ -63,4 +63,44 @@ final class CloudKitSyncModeTests: XCTestCase {
         let controller = PersistenceController(useCloudKit: true, inMemory: true)
         XCTAssertTrue(controller.isUsingCloudKit)
     }
+
+    // MARK: - performBackgroundTask async timing
+
+    /// waitUntilLoaded()がloadPersistentStoresの非同期完了を正しく待つことを確認する。
+    /// 手動のディレイなしですぐperformBackgroundTaskを呼んでもレースせず、
+    /// ストア読み込み完了後に安全に実行されることを検証する（issue #98）。
+    func testPerformBackgroundTask_happyPath_waitsForStoreLoadAndSucceeds() async throws {
+        let controller = PersistenceController(useCloudKit: false, inMemory: true)
+
+        let result = try await controller.performBackgroundTask { _ in 1 }
+
+        XCTAssertEqual(result, 1)
+    }
+
+    /// ストアの読み込みが実際に失敗した場合、performBackgroundTaskが
+    /// PersistenceError.storeNotAvailableを投げることを確認する（issue #98）。
+    ///
+    /// 当初は「存在しないディレクトリ配下のURL」で失敗注入を試みたが、
+    /// NSPersistentContainerが中間ディレクトリを自動作成してロードに成功してしまうことが
+    /// 実測で判明した。そこで、既存のディレクトリそのものをストアURLとして渡すことで、
+    /// SQLiteが「ファイルとして開けない（ディレクトリである）」という実際のCoreData読み込み
+    /// 失敗を注入する。
+    func testPerformBackgroundTask_storeLoadFailure_throwsStoreNotAvailable() async {
+        // 既存のディレクトリをそのままストアURLとして渡す。
+        // ディレクトリはSQLiteファイルとして開けないため、実際のロード失敗が発生する。
+        let storeURL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        let controller = PersistenceController(useCloudKit: false, inMemory: false, storeURL: storeURL)
+
+        do {
+            _ = try await controller.performBackgroundTask { _ in 1 }
+            XCTFail("ストア読み込み失敗時はエラーが投げられるべき")
+        } catch let error as PersistenceError {
+            switch error {
+            case .storeNotAvailable:
+                break
+            }
+        } catch {
+            XCTFail("PersistenceError.storeNotAvailableが投げられるべきだが\(error)が投げられた")
+        }
+    }
 }


### PR DESCRIPTION
## 概要
issue #98 で指摘された、直近の非同期タイミング系クラッシュ修正（CloudKit同期時のCoreDataストア未読み込みアクセス、PiP中の書き込み遅延）に対応するテストが無かった問題に対応。3つのサブ項目すべてにテストを追加した。

## 変更内容

### 1. `PersistenceController`（読み込み失敗の注入フック）
- `init(useCloudKit:inMemory:storeURL:)` に `storeURL: URL? = nil` パラメータを追加。非nilの場合はApp Groupコンテナのルックアップをスキップし、そのURLから直接ストアを構成する（history tracking / remote change通知 / マイグレーション / file protection / CloudKitオプションは既存の非nil-groupURL分岐と同じ設定を適用）。デフォルトはnilなので既存の呼び出し元・挙動に影響なし。
- `CloudKitSyncModeTests.swift` に2テストを追加:
  - `testPerformBackgroundTask_happyPath_waitsForStoreLoadAndSucceeds`: `inMemory: true` で作成直後に `performBackgroundTask` を呼び、`waitUntilLoaded()` が非同期ロード完了を正しく待ってレースしないことを確認。
  - `testPerformBackgroundTask_storeLoadFailure_throwsStoreNotAvailable`: ストア読み込みが実際に失敗した場合に `PersistenceError.storeNotAvailable` が投げられることを確認。
  - **判断ログ**: 当初issueの提案通り「存在しないディレクトリ配下のURL」で失敗を注入しようとしたが、実測したところ `NSPersistentContainer` が中間ディレクトリを自動作成しロードに成功してしまい、テストが red になった（`XCTFail` が発火）。そこで「既存のディレクトリそのものをストアURLとして渡す」方式に変更し、SQLiteがそれをファイルとして開けず実際に失敗するようにした（実測で green を確認済み）。

### 2. `ClipboardHistoryFeature`（addItemのoverflow分岐）
`ClipboardHistoryFeatureTests.swift` に2テストを追加:
- `testAddItem_nonPiP_overflowCallsDeleteItem`: 非PiP時、20件超過で `deleteItem` が追い出された最古アイテムに対して1回呼ばれることを確認。
- `testAddItem_piPActive_overflowSkipsDeleteItemAndBuffersItem`: PiP中は `deleteItem` が呼ばれず（CoreData書き込み回避）、代わりに新アイテムが `pendingItemBuffer.append` に積まれることを確認。`items.count == 20` と先頭が新アイテムであることも検証。

### 3. `ClipboardItemRow`（空テキスト表示ロジック）
- `itemContent` の `.text` ケースにインラインしていたプレースホルダー判定ロジックを `static func displayText(for:) -> (text: String, isEmpty: Bool)` として切り出し。表示側の見た目（font/color）は `isEmpty` 駆動に変更したのみで挙動は同一。
- 新規 `ClipboardItemRowTests.swift` を追加し、nil / 空文字列 / 通常テキストの3ケースを検証。

## ハーネス実行結果（全て green）

**swiftlint lint**
```
Done linting! Found 75 violations, 0 serious in 66 files.
```
変更・追加したファイル（PersistenceController.swift / ClipboardItemRow.swift / ClipboardHistoryFeatureTests.swift / CloudKitSyncModeTests.swift / ClipboardItemRowTests.swift）には違反0件。既存の75件はすべて他ファイルの既存warning。

**xcodebuild test**（-project copyPaste.xcodeproj -scheme ClipKit -destination "id=1E50E1DA-8FF4-4D0E-B8AE-CDE1467FA046"）
```
Test Suite 'All tests' passed at 2026-07-15 20:22:32.725.
** TEST SUCCEEDED **
```
新規追加した7件のテストすべてpassedを確認済み（testPerformBackgroundTask_happyPath_waitsForStoreLoadAndSucceeds / testPerformBackgroundTask_storeLoadFailure_throwsStoreNotAvailable / testAddItem_nonPiP_overflowCallsDeleteItem / testAddItem_piPActive_overflowSkipsDeleteItemAndBuffersItem / testDisplayText_nilContent... など）。

注記: 1回目の実行では `ClipKitUITests.testLaunchPerformance()` がシミュレータの再起動関連（`FBSOpenApplicationServiceErrorDomain`, `Mach error -308`）で不安定に落ちたが、これは今回の変更と無関係のシミュレータ環境要因。2回目のフル実行では全129テストがpassedで再現しなかった。

**xcodebuild build**
```
** BUILD SUCCEEDED **
```

## Refs
Refs #98